### PR TITLE
Added an env to disable the extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ services:
       - /dev:/dev:rw
       - ./irdm.conf:/opt/irdm.conf:ro
     environment:
+#      - DISABLE_EXTRACTOR=true
 #      - LOG_EXTRACTOR_STATS=true
 #      - LOG_MAP=true
 #      - EXTRACTOR_ARGS= -D 10

--- a/rootfs/etc/s6-overlay/s6-rc.d/iridium-extractor/run
+++ b/rootfs/etc/s6-overlay/s6-rc.d/iridium-extractor/run
@@ -1,10 +1,17 @@
 #!/command/with-contenv bash
 #shellcheck shell=bash
 
-echo "Starting iridium-extractor and iridium-parser"
-
-if [[ -n ${LOG_EXTRACTOR_STATS} ]]; then
-    python3 -u `which iridium-extractor` $EXTRACTOR_ARGS /opt/irdm.conf 2> >(stdbuf -o0 awk '{print "[iridium-extractor] " strftime("%Y/%m/%d %H:%M:%S", systime()) " " $0}') > >(pypy3 -u /opt/iridium-toolkit/iridium-parser.py $PARSER_ARGS -o zmq 2>&1 | stdbuf -o0 awk '{print "[iridium-parser] " strftime("%Y/%m/%d %H:%M:%S", systime()) " " $0}')
+if [[ -n ${DISABLE_EXTRACTOR} ]]; then
+    echo "Not starting Extractor as it is disabled in the yml. You should know what you're doing."
+    sleep infinity
+    exit 0
 else
-    python3 -u `which iridium-extractor` $EXTRACTOR_ARGS /opt/irdm.conf 2> >(stdbuf -o0 awk '{print "[iridium-extractor] " strftime("%Y/%m/%d %H:%M:%S", systime()) " " $0}' | grep WARNING) > >(pypy3 -u /opt/iridium-toolkit/iridium-parser.py $PARSER_ARGS -o zmq 2>&1 | stdbuf -o0 awk '{print "[iridium-parser] " strftime("%Y/%m/%d %H:%M:%S", systime()) " " $0}')
+
+  echo "Starting iridium-extractor and iridium-parser"
+
+  if [[ -n ${LOG_EXTRACTOR_STATS} ]]; then
+      python3 -u `which iridium-extractor` $EXTRACTOR_ARGS /opt/irdm.conf 2> >(stdbuf -o0 awk '{print "[iridium-extractor] " strftime("%Y/%m/%d %H:%M:%S", systime()) " " $0}') > >(pypy3 -u /opt/iridium-toolkit/iridium-parser.py $PARSER_ARGS -o zmq 2>&1 | stdbuf -o0 awk '{print "[iridium-parser] " strftime("%Y/%m/%d %H:%M:%S", systime()) " " $0}')
+  else
+      python3 -u `which iridium-extractor` $EXTRACTOR_ARGS /opt/irdm.conf 2> >(stdbuf -o0 awk '{print "[iridium-extractor] " strftime("%Y/%m/%d %H:%M:%S", systime()) " " $0}' | grep WARNING) > >(pypy3 -u /opt/iridium-toolkit/iridium-parser.py $PARSER_ARGS -o zmq 2>&1 | stdbuf -o0 awk '{print "[iridium-parser] " strftime("%Y/%m/%d %H:%M:%S", systime()) " " $0}')
+  fi
 fi


### PR DESCRIPTION
If the env DISABLE_EXTRACTOR=true is set, then the extractor won't be started.
Helpful if you want to do a hybrid approach with the extractor running bare metal (due to e.g. driver problems (sdrplay, I look at you)).
Start the container in host mode and it'll grab the data from the extractor via zmq.